### PR TITLE
fixes optimality gap bug in nonlinear

### DIFF
--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -565,9 +565,9 @@ function MathProgBase.optimize!(m::PajaritoModel)
         end
         # add supporting hyperplanes
         if m.objsense == :Min
-            optimality_gap = nlp_objval - mip_objval
+            optimality_gap = m.objval - mip_objval
         else
-            optimality_gap = -nlp_objval - mip_objval
+            optimality_gap = -m.objval - mip_objval
         end
         (m.verbose > 0) && (m.algorithm == "OA") && @printf "%9d   %13.2f   %15.2f   %14.2f   %13.2f\n" iter mip_objval nlp_objval optimality_gap m.objval
         if inf_cut_generator || optimality_gap > (abs(mip_objval) + 1e-5)*m.opt_tolerance || cb != []


### PR DESCRIPTION
This PR fixes a bug when optimality gap was calculated using nlp_objval instead of best known objective m.objval.