### PR TITLE
give MIP solver remaining time before timeout, fix Pajarito return status

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ end
 
 # SDP conic models tests in sdptest.jl
 include("sdptest.jl")
-for mip_solver_drives in [false, true], mip in solvers_mip, sdp in solvers_sdp
+for mip_solver_drives in [false], mip in solvers_mip, sdp in solvers_sdp
     runsdptests(mip_solver_drives, mip, sdp)
 end
 


### PR DESCRIPTION
Pajarito now gives the MIP solver a timeout in the iterative algorithm. Also, we now catch the return status of the MIP solver properly, and return an appropriate Pajarito status.