### PR TITLE
fix mip_obj uninitialized and timeout check

### DIFF
--- a/src/conic_algorithm.jl
+++ b/src/conic_algorithm.jl
@@ -229,6 +229,7 @@ type PajaritoConicModel <: MathProgBase.AbstractConicModel
 
         m.oa_started = false
         m.best_obj = Inf
+        m.mip_obj = -Inf
         m.best_int = Float64[]
         m.best_sub = Float64[]
         m.status = :NotLoaded
@@ -1153,7 +1154,7 @@ function solve_iterative!(m::PajaritoConicModel, logs::Dict{Symbol,Real})
                     m.mip_obj = mip_obj_bound
                 end
             end
-            if status_mip == :UserLimit && ((time() - logs[:oa_alg]) > (m.timeout - 0.01))
+            if status_mip == :UserLimit && ((time() - logs[:total]) > (m.timeout - 0.01))
                 m.status = :UserLimit
                 break
             end


### PR DESCRIPTION
Running the classical_200_1 instance with 60-second timeout on the MIP exposed two issues:
1. If the first MIP solve times out, then ``m.mip_obj`` is used before being initialized
2. The mip solve timed out and then the algorithm kept running because of the difference between ``logs[:oa_alg]`` and ``logs[:total]``.