### PR TITLE
Update MathProgBase bounds

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
-MathProgBase 0.4 0.6
+MathProgBase 0.5 0.7
 JuMP 0.15
 ConicNonlinearBridge


### PR DESCRIPTION
Enables compatibility with JuMP 0.16.