### PR TITLE
Remove default solver in solver.jl (use dummy) and revert expdesign back

### DIFF
--- a/examples/expdesign.jl
+++ b/examples/expdesign.jl
@@ -135,12 +135,12 @@ np = @variable(dOpt, [j=1:p], Int, lowerbound=0, upperbound=nmax)
 @constraint(dOpt, sum(np) <= n)
 @objective(dOpt, Max, scaledGeomean(dOpt, eigenvals(dOpt, V * diagm(np./n) * V')))
 
-(c, A, b, var_cones, con_cones) = JuMP.conicdata(dOpt)
-@show c
-@show A
-@show b
-@show var_cones
-@show con_cones
+# (c, A, b, var_cones, con_cones) = JuMP.conicdata(dOpt)
+# @show c
+# @show A
+# @show b
+# @show var_cones
+# @show con_cones
 
 solve(dOpt)
 println("\n  objective $(getobjectivevalue(dOpt))")

--- a/examples/expdesign.jl
+++ b/examples/expdesign.jl
@@ -6,11 +6,11 @@ using Convex, JuMP, Pajarito
 log_level = 3
 mip_solver_drives = false
 
-# using SCS
-# cont_solver = SCSSolver(eps=1e-6, max_iters=1000000, verbose=0)
+using SCS
+cont_solver = SCSSolver(eps=1e-6, max_iters=1000000, verbose=0)
 
-using Mosek
-cont_solver = MosekSolver(LOG=0)
+# using Mosek
+# cont_solver = MosekSolver(LOG=0)
 
 # using Cbc
 # mip_solver = CbcSolver()
@@ -19,12 +19,13 @@ cont_solver = MosekSolver(LOG=0)
 using CPLEX
 mip_solver = CplexSolver(
     CPX_PARAM_SCRIND=(mip_solver_drives ? 1 : 0),
-    CPX_PARAM_EPINT=1e-8,
-    CPX_PARAM_EPRHS=1e-8,
+    CPX_PARAM_EPINT=1e-9,
+    CPX_PARAM_EPRHS=1e-9,
     CPX_PARAM_EPGAP=(mip_solver_drives ? 1e-5 : 0))
 
 
 solver = PajaritoSolver(
+    rel_gap=1e-5,
 	mip_solver_drives=mip_solver_drives,
 	mip_solver=mip_solver,
 	cont_solver=cont_solver,
@@ -134,12 +135,12 @@ np = @variable(dOpt, [j=1:p], Int, lowerbound=0, upperbound=nmax)
 @constraint(dOpt, sum(np) <= n)
 @objective(dOpt, Max, scaledGeomean(dOpt, eigenvals(dOpt, V * diagm(np./n) * V')))
 
-# (c, A, b, var_cones, con_cones) = JuMP.conicdata(dOpt)
-# @show c
-# @show A
-# @show b
-# @show var_cones
-# @show con_cones
+(c, A, b, var_cones, con_cones) = JuMP.conicdata(dOpt)
+@show c
+@show A
+@show b
+@show var_cones
+@show con_cones
 
 solve(dOpt)
 println("\n  objective $(getobjectivevalue(dOpt))")

--- a/examples/expdesign.jl
+++ b/examples/expdesign.jl
@@ -6,18 +6,22 @@ using Convex, JuMP, Pajarito
 log_level = 3
 mip_solver_drives = false
 
-using SCS
-cont_solver = SCSSolver(eps=1e-6, max_iters=1000000, verbose=0)
+# using SCS
+# cont_solver = SCSSolver(eps=1e-6, max_iters=1000000, verbose=0)
 
-# using Mosek
-# cont_solver = MosekSolver(LOG=0)
+using Mosek
+cont_solver = MosekSolver(LOG=0)
 
 # using Cbc
 # mip_solver = CbcSolver()
 # mip_solver_drives = false
 
 using CPLEX
-mip_solver = CplexSolver(CPX_PARAM_SCRIND=(mip_solver_drives ? 1 : 0), CPX_PARAM_EPINT=1e-8, CPX_PARAM_EPRHS=1e-6, CPX_PARAM_EPGAP=0.)
+mip_solver = CplexSolver(
+    CPX_PARAM_SCRIND=(mip_solver_drives ? 1 : 0),
+    CPX_PARAM_EPINT=1e-8,
+    CPX_PARAM_EPRHS=1e-8,
+    CPX_PARAM_EPGAP=(mip_solver_drives ? 1e-5 : 0))
 
 
 solver = PajaritoSolver(
@@ -91,7 +95,7 @@ println("  solution\n$(np.value)")
 #   subject to  sum(lambda)=1,  lambda >=0
 println("\n\n****D optimal: JuMP.jl****\n")
 
-function eigenvals(dOpt, A::Array{JuMP.Variable,2})
+function eigenvals(dOpt, A)
     dimA = size(A,1)
     U = @variable(dOpt, [i=1:dimA, j=i:dimA])
     for i in 1:dimA
@@ -103,7 +107,7 @@ function eigenvals(dOpt, A::Array{JuMP.Variable,2})
     return [U[i,i] for i in 1:dimA]
 end
 
-function scaledGeomean(dOpt, x::Vector{JuMP.Variable})
+function scaledGeomean(dOpt, x)
     dimx = length(x)
     if dimx > 2
         dimxbar = Int(2^ceil(log(2, dimx)))
@@ -119,7 +123,7 @@ function scaledGeomean(dOpt, x::Vector{JuMP.Variable})
     end
 end
 
-function geomean(dOpt, x::JuMP.Variable, y::JuMP.Variable) # SOCRotated
+function geomean(dOpt, x, y) # SOCRotated
     t = @variable(dOpt, lowerbound=0)
     @constraint(dOpt, x*y >= t^2)
     return t
@@ -128,10 +132,7 @@ end
 dOpt = Model(solver=solver)
 np = @variable(dOpt, [j=1:p], Int, lowerbound=0, upperbound=nmax)
 @constraint(dOpt, sum(np) <= n)
-Q = @variable(dOpt, [1:q,1:q], Symmetric)
-T = V * diagm(np./n) * V'
-@constraint(dOpt, [i1=1:q,i2=i1:q], Q[i1,i2] == T[i1,i2])
-@objective(dOpt, Max, scaledGeomean(dOpt, eigenvals(dOpt, Q)))
+@objective(dOpt, Max, scaledGeomean(dOpt, eigenvals(dOpt, V * diagm(np./n) * V')))
 
 # (c, A, b, var_cones, con_cones) = JuMP.conicdata(dOpt)
 # @show c
@@ -181,14 +182,11 @@ println("\n\n****A optimal: JuMP.jl****\n")
 aOpt = Model(solver=solver)
 np = @variable(aOpt, [j=1:p], Int, lowerbound=0, upperbound=nmax)
 @constraint(aOpt, sum(np) <= n)
-Q = @variable(aOpt, [1:q,1:q], Symmetric)
-T = V * diagm(np./n) * V'
-@constraint(aOpt, [i1=1:q,i2=i1:q], Q[i1,i2] == T[i1,i2])
 u = @variable(aOpt, [i=1:q], lowerbound=0)
 @objective(aOpt, Min, sum(u))
 E = eye(q)
 for i=1:q
-    @SDconstraint(aOpt, [Q E[:,i]; E[i,:]' u[i]] >= 0)
+    @SDconstraint(aOpt, [V * diagm(np./n) * V' E[:,i]; E[i,:]' u[i]] >= 0)
 end
 
 # (c, A, b, var_cones, con_cones) = JuMP.conicdata(aOpt)
@@ -237,12 +235,9 @@ println("\n\n****E optimal: JuMP.jl****\n")
 eOpt = Model(solver=solver)
 np = @variable(eOpt, [j=1:p], Int, lowerbound=0, upperbound=nmax)
 @constraint(eOpt, sum(np) <= n)
-Q = @variable(eOpt, [1:q,1:q], Symmetric)
-T = V * diagm(np./n) * V'
-@constraint(eOpt, [i1=1:q,i2=i1:q], Q[i1,i2] == T[i1,i2])
 t = @variable(eOpt)
 @objective(eOpt, Max, t)
-@SDconstraint(eOpt, Q - t * eye(q) >= 0)
+@SDconstraint(eOpt, V * diagm(np./n) * V' - t * eye(q) >= 0)
 
 # (c, A, b, var_cones, con_cones) = JuMP.conicdata(eOpt)
 # @show c

--- a/src/conic_algorithm.jl
+++ b/src/conic_algorithm.jl
@@ -231,21 +231,18 @@ function MathProgBase.loadproblem!(m::PajaritoConicModel, c, A, b, cone_con, con
     # Verify consistency of conic data
     verify_data(m, c, A, b, cone_con, cone_var)
 
-    # Verify cone compatibility with solver (if solver is not defaultConicsolver: an MPB issue)
-    if m.cont_solver != MathProgBase.defaultConicsolver
-        # Get cones supported by conic solver
-        conic_spec = MathProgBase.supportedcones(m.cont_solver)
+    # Verify cone compatibility with conic solver
+    conic_spec = MathProgBase.supportedcones(m.cont_solver)
 
-        # Pajarito converts rotated SOCs to standard SOCs
-        if :SOC in conic_spec
-            push!(conic_spec, :SOCRotated)
-        end
+    # Pajarito converts rotated SOCs to standard SOCs
+    if :SOC in conic_spec
+        push!(conic_spec, :SOCRotated)
+    end
 
-        # Error if a cone in data is not supported
-        for (spec, _) in vcat(cone_con, cone_var)
-            if !(spec in conic_spec)
-                error("Cones $spec are not supported by the specified conic solver\n")
-            end
+    # Error if a cone in data is not supported
+    for (spec, _) in vcat(cone_con, cone_var)
+        if !(spec in conic_spec)
+            error("Cones $spec are not supported by the specified conic solver\n")
         end
     end
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -54,13 +54,13 @@ function PajaritoSolver(;
     rel_gap = 1e-5,
 
     mip_solver_drives = false,
-    mip_solver = MathProgBase.defaultMIPsolver,
-    mip_subopt_solver = MathProgBase.defaultMIPsolver,
+    mip_solver = nothing,
+    mip_subopt_solver = nothing,
     mip_subopt_count = 0,
     round_mip_sols = false,
     pass_mip_sols = true,
 
-    cont_solver = MathProgBase.defaultConicsolver,
+    cont_solver = nothing,
     solve_relax = true,
     dualize_relax = false,
     dualize_sub = false,
@@ -87,6 +87,16 @@ function PajaritoSolver(;
     tol_prim_infeas = 1e-6,
     )
 
+    if mip_solver == nothing
+        error("No MIP solver specified\n")
+    end
+    if (mip_subopt_solver == nothing) && (mip_subopt_count > 0)
+        error("Using suboptimal solves, but no suboptimal MIP solver specified\n")
+    end
+    if cont_solver == nothing
+        error("No continuous solver specified\n")
+    end
+    
     if viol_cuts_only == nothing
         # If user has not set option, default is true on MSD and false on iterative
         viol_cuts_only = mip_solver_drives

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -9,6 +9,13 @@ This file implements the default PajaritoSolver
 
 export PajaritoSolver
 
+
+# Dummy solver
+type UnsetSolver <: MathProgBase.AbstractMathProgSolver
+end
+
+
+# Pajarito solver
 immutable PajaritoSolver <: MathProgBase.AbstractMathProgSolver
     log_level::Int              # Verbosity flag: 0 for minimal information, 1 for basic solve statistics, 2 for iteration information, 3 for cone information
     timeout::Float64            # Time limit for outer approximation algorithm not including initial load (in seconds)
@@ -54,13 +61,13 @@ function PajaritoSolver(;
     rel_gap = 1e-5,
 
     mip_solver_drives = false,
-    mip_solver = nothing,
-    mip_subopt_solver = nothing,
+    mip_solver = UnsetSolver(),
+    mip_subopt_solver = UnsetSolver(),
     mip_subopt_count = 0,
     round_mip_sols = false,
     pass_mip_sols = true,
 
-    cont_solver = nothing,
+    cont_solver = UnsetSolver(),
     solve_relax = true,
     dualize_relax = false,
     dualize_sub = false,
@@ -87,16 +94,16 @@ function PajaritoSolver(;
     tol_prim_infeas = 1e-6,
     )
 
-    if mip_solver == nothing
-        error("No MIP solver specified\n")
+    if mip_solver == UnsetSolver()
+        error("No MIP solver specified (set mip_solver)\n")
     end
-    if (mip_subopt_solver == nothing) && (mip_subopt_count > 0)
-        error("Using suboptimal solves, but no suboptimal MIP solver specified\n")
+    if (mip_subopt_solver == UnsetSolver()) && (mip_subopt_count > 0)
+        error("Using suboptimal solves (mip_subopt_count > 0), but no suboptimal MIP solver specified (set mip_subopt_solver)\n")
     end
-    if cont_solver == nothing
-        error("No continuous solver specified\n")
+    if cont_solver == UnsetSolver()
+        error("No continuous solver specified (set cont_solver)\n")
     end
-    
+
     if viol_cuts_only == nothing
         # If user has not set option, default is true on MSD and false on iterative
         viol_cuts_only = mip_solver_drives


### PR DESCRIPTION
default solvers have been removed in JuMP. Pajarito now seems to work with JuMP 0.16

with JuMP now detecting symmetry with epsilon, no need to add extra variables and constraints in exp design models