### PR TITLE
copy cont and mip solvers in solver.jl in case modify options

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -108,7 +108,8 @@ function PajaritoSolver(;
         viol_cuts_only = mip_solver_drives
     end
 
-    PajaritoSolver(log_level, timeout, rel_gap, mip_solver_drives, mip_solver, mip_subopt_solver, mip_subopt_count, round_mip_sols, pass_mip_sols, cont_solver, solve_relax, solve_subp, dualize_relax, dualize_subp, soc_disagg, soc_abslift, soc_in_mip, sdp_eig, sdp_soc, init_soc_one, init_soc_inf, init_exp, init_sdp_lin, init_sdp_soc, scale_subp_cuts, scale_factor, viol_cuts_only, prim_cuts_only, prim_cuts_always, prim_cuts_assist, tol_zero, tol_prim_infeas)
+    # Deepcopy the solvers because we may change option values inside Pajarito
+    PajaritoSolver(log_level, timeout, rel_gap, mip_solver_drives, deepcopy(mip_solver), deepcopy(mip_subopt_solver), mip_subopt_count, round_mip_sols, pass_mip_sols, deepcopy(cont_solver), solve_relax, solve_subp, dualize_relax, dualize_subp, soc_disagg, soc_abslift, soc_in_mip, sdp_eig, sdp_soc, init_soc_one, init_soc_inf, init_exp, init_sdp_lin, init_sdp_soc, scale_subp_cuts, scale_factor, viol_cuts_only, prim_cuts_only, prim_cuts_always, prim_cuts_assist, tol_zero, tol_prim_infeas)
 end
 
 


### PR DESCRIPTION
better to copy them in solver.jl instead of in tests (cancel #324). users may get confused if they are solving multiple problems with the same solver object as options can be modified inside pajarito.

fixes #323 